### PR TITLE
Update endpoints and fields of Linkedin api

### DIFF
--- a/spec/omniauth/strategies/linkedin_spec.rb
+++ b/spec/omniauth/strategies/linkedin_spec.rb
@@ -30,7 +30,7 @@ describe OmniAuth::Strategies::LinkedIn do
 
   describe '#uid' do
     before :each do
-      allow(subject).to receive(:raw_info) { Hash['id' => 'uid'] }
+      allow(subject).to receive(:raw_info) { Hash['sub' => 'uid'] }
     end
 
     it 'returns the id from raw_info' do
@@ -43,18 +43,12 @@ describe OmniAuth::Strategies::LinkedIn do
 
     let(:parsed_response) { Hash[:foo => 'bar'] }
 
-    let(:profile_endpoint) { '/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))' }
-    let(:email_address_endpoint) { '/v2/emailAddress?q=members&projection=(elements*(handle~))' }
+    let(:profile_endpoint) { '/v2/userinfo' }
 
-    let(:email_address_response) { instance_double OAuth2::Response, parsed: parsed_response }
     let(:profile_response) { instance_double OAuth2::Response, parsed: parsed_response }
 
     before :each do
       allow(subject).to receive(:access_token).and_return access_token
-
-      allow(access_token).to receive(:get)
-        .with(email_address_endpoint)
-        .and_return(email_address_response)
 
       allow(access_token).to receive(:get)
         .with(profile_endpoint)
@@ -108,7 +102,7 @@ describe OmniAuth::Strategies::LinkedIn do
       end
 
       it 'sets default scope' do
-        expect(subject.authorize_params['scope']).to eq('r_liteprofile r_emailaddress')
+        expect(subject.authorize_params['scope']).to eq('profile email w_member_social openid')
       end
     end
   end


### PR DESCRIPTION
* Change default scope to include `openid`
* Get uid from `raw_info['sub']`
* Get profile from `/v2/userinfo` endpoint